### PR TITLE
prevent circular references

### DIFF
--- a/lib/MojoX/NetstringStream.pm
+++ b/lib/MojoX/NetstringStream.pm
@@ -3,6 +3,7 @@ package MojoX::NetstringStream;
 use Mojo::Base 'Mojo::EventEmitter';
 
 use Carp;
+use Scalar::Util qw(weaken);
 
 our $VERSION  = '0.06';
 
@@ -21,8 +22,11 @@ sub new {
 	$self->{debug} = $args{debug} // 0;
 	$self->{maxsize} = $args{maxsize};
 	$stream->timeout(0);
-	$stream->on(read => sub{ $self->_on_read(@_); });
-	$stream->on(close => sub{ $self->_on_close(@_); });
+	{
+		weaken (my $self = $self);
+		$stream->on(read => sub{ $self->_on_read(@_); });
+		$stream->on(close => sub{ $self->_on_close(@_); });
+	}
 	return $self;
 }
 


### PR DESCRIPTION
This is the change I am least sure of. It's possible that on read / write should have a check to see if `$self` disappeared but I'm not sure if that is the correct behaviour or actually erroring because it disappeared is correct.